### PR TITLE
Get rid of unicode error

### DIFF
--- a/dblite/__init__.py
+++ b/dblite/__init__.py
@@ -92,6 +92,7 @@ class Storage(object):
         # sqlite connection
         try:
             self._conn = sqlite3.connect(database)
+            self._conn.text_factory = str
         except sqlite3.OperationalError, err:
             raise RuntimeError("%s, database: %s" % (err, database))
         self._conn.row_factory = self._dict_factory


### PR DESCRIPTION
Simple solution based on:
http://stackoverflow.com/questions/3425320/sqlite3-programmingerror-you-must-not-use-8-bit-bytestrings-unless-you-use-a-te

Please let me know if another solution needed for this problem and I'll try to change it.