### PR TITLE
Fixed bug: path to database can contain colons now

### DIFF
--- a/dblite/__init__.py
+++ b/dblite/__init__.py
@@ -4,7 +4,7 @@
 #   simple library for stroring python dictionaries in sqlite database
 #
 __author__ = 'Andrey Usov <https://github.com/ownport/scrapy-dblite>'
-__version__ = '0.2.6'
+__version__ = '0.2.7'
 
 import os
 import re
@@ -127,7 +127,9 @@ class Storage(object):
         backend, rest_uri = uri.split('://')
         if backend not in SUPPORTED_BACKENDS:
             raise RuntimeError('Unknown backend: {}'.format(backend))
-        database, table = rest_uri.split(':')
+        delimiter_pos = rest_uri.rfind(':')
+        database = rest_uri[:delimiter_pos]
+        table = rest_uri[delimiter_pos + 1:]
 
         return database, table
 


### PR DESCRIPTION
Hi!

I wanted to use absolute path on Windows, but scrapy-dblite was crashing. It's caused by a colon in path. scrapy-dblite wasn't crashing only on Windows - colons are also acceptable in unix/linux paths. I fixed this bug.

Regards,
Mrowqa